### PR TITLE
Fix width for long torrent names

### DIFF
--- a/mobile.css
+++ b/mobile.css
@@ -16,3 +16,28 @@ html, body {
 .hiddenPath {
 	display: none;
 }
+h5, #detailsTrackersPage a, #detailsFilesPage a {
+	word-break:break-all;
+	word-break:break-word;
+}
+#detailsFilesPage > div {
+	padding-right: 44px;
+	margin-right: 0 !important;
+}
+#detailsFilesPage div {
+	margin-right: -44px;
+}
+#detailsFilesPage button.btn {
+	margin-right: -44px;
+}
+#detailsFilesPage a {
+	display: inline-block;
+	margin-left: 14px;
+}
+#detailsFilesPage .icon-file {
+	position: absolute;
+	margin-left: -14px;
+}
+select {
+	width:auto;
+}


### PR DESCRIPTION
The word-break directive makes a long string break to wrap even in a
non-breakable place in order to stay with in the width of it's parent
element.  This makes it so that there is never any horizontal scrolling
required because the torrent names etc. just wrap to the next line.
